### PR TITLE
katacoda: use bootcamp image from gcr.io/google-samples

### DIFF
--- a/code/katacoda/module3.sh
+++ b/code/katacoda/module3.sh
@@ -38,4 +38,4 @@ echo 'esac' >> ~/.bin/minikube
 chmod +x ~/.bin/minikube
 echo 'export KUBERNETES_MASTER=http://host01:8080' >> ~/.bashrc
 ~/.bin/minikube start
-kubectl run kubernetes-bootcamp --image=docker.io/jocatalin/kubernetes-bootcamp:v1 --port=8080
+kubectl run kubernetes-bootcamp --image=gcr.io/google-samples/kubernetes-bootcamp:v1 --port=8080

--- a/code/katacoda/module4.sh
+++ b/code/katacoda/module4.sh
@@ -38,4 +38,4 @@ echo 'esac' >> ~/.bin/minikube
 chmod +x ~/.bin/minikube
 echo 'export KUBERNETES_MASTER=http://host01:8080' >> ~/.bashrc
 ~/.bin/minikube start
-kubectl run kubernetes-bootcamp --image=docker.io/jocatalin/kubernetes-bootcamp:v1 --port=8080
+kubectl run kubernetes-bootcamp --image=gcr.io/google-samples/kubernetes-bootcamp:v1 --port=8080

--- a/code/katacoda/module5.sh
+++ b/code/katacoda/module5.sh
@@ -38,5 +38,5 @@ echo 'esac' >> ~/.bin/minikube
 chmod +x ~/.bin/minikube
 echo 'export KUBERNETES_MASTER=http://host01:8080' >> ~/.bashrc
 ~/.bin/minikube start
-kubectl run kubernetes-bootcamp --image=docker.io/jocatalin/kubernetes-bootcamp:v1 --port=8080
+kubectl run kubernetes-bootcamp --image=gcr.io/google-samples/kubernetes-bootcamp:v1 --port=8080
 kubectl expose deployments/kubernetes-bootcamp --type="NodePort" --port 8080

--- a/code/katacoda/module6.sh
+++ b/code/katacoda/module6.sh
@@ -38,5 +38,5 @@ echo 'esac' >> ~/.bin/minikube
 chmod +x ~/.bin/minikube
 echo 'export KUBERNETES_MASTER=http://host01:8080' >> ~/.bashrc
 ~/.bin/minikube start
-kubectl run kubernetes-bootcamp --image=docker.io/jocatalin/kubernetes-bootcamp:v1 --port=8080 --replicas=4
+kubectl run kubernetes-bootcamp --image=gcr.io/google-samples/kubernetes-bootcamp:v1 --port=8080 --replicas=4
 kubectl expose deployments/kubernetes-bootcamp --type="NodePort" --port 8080


### PR DESCRIPTION
Instruct users to download the bootcamp image from `gcr.io/google-samples` instead of from a Kubernetes community member's Docker repository.

FYI @jeffmendoza @pwittrock @ahmetb 

edit 2017-08-09: closes #13